### PR TITLE
Fix system_umask type

### DIFF
--- a/manifests/umask.pp
+++ b/manifests/umask.pp
@@ -12,7 +12,7 @@
 # @param system_umask
 #
 class os_hardening::umask (
-  Optional[Integer] $system_umask = undef,
+  Optional[String] $system_umask = undef,
 ) {
   if $system_umask != undef {
     file { '/etc/profile.d/umask.sh':


### PR DESCRIPTION
On init.pp it's declared $system_umask as `Optional[String]`, but on umask.pp it's declared as `Optional[Integer]`. 